### PR TITLE
ヘッダーナビゲーションを短くする

### DIFF
--- a/sukki-skicker-client/components/Header.vue
+++ b/sukki-skicker-client/components/Header.vue
@@ -6,10 +6,10 @@
           {{ user.username }}
         </li>
         <li>
-          <nuxt-link to="/">すきすきする</nuxt-link>
+          <nuxt-link to="/">すきを送る</nuxt-link>
         </li>
         <li>
-          <nuxt-link to="/skickers">火力を上げる</nuxt-link>
+          <nuxt-link to="/skickers">火力</nuxt-link>
         </li>
         <li>
           <nuxt-link to="/mypage">マイページ</nuxt-link>

--- a/sukki-skicker-client/components/Header.vue
+++ b/sukki-skicker-client/components/Header.vue
@@ -3,7 +3,7 @@
     <nav>
       <ul>
         <li>
-          {{ user.username }}
+          {{ user.username.slice(0, 3) }}
         </li>
         <li>
           <nuxt-link to="/">すきを送る</nuxt-link>


### PR DESCRIPTION
- 左上のユーザ名の表示を3文字までにする
- メニューの項目名を短くする